### PR TITLE
Automatic interval based on time

### DIFF
--- a/src/components/TimePickerGenerator.vue
+++ b/src/components/TimePickerGenerator.vue
@@ -48,7 +48,7 @@ export default {
       MINUTES,
       HOURS,
       TWELVE_HOURS,
-      interval: 'AM'
+      interval: this.hour < 12 ? 'AM' : 'PM'
     }
   },
   components: {


### PR DESCRIPTION
Set interval automatically when opening the time picker.

Instead of
![image](https://cloud.githubusercontent.com/assets/15309804/24658062/811520ac-1940-11e7-9165-097b302d9350.png)

It shows
![image](https://cloud.githubusercontent.com/assets/15309804/24658095/9a77c6da-1940-11e7-9829-fdd20716dd5c.png)
